### PR TITLE
Read Configuration at App Start

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 
 import {MaterialModule } from './material.module';
 
@@ -11,6 +11,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DayOneComponent } from './day-one/day-one.component';
 import { DayTwoComponent } from './day-two/day-two.component';
 import { NumbersSpacesDirective } from './directives/numbers-spaces.directive';
+import { AppConfigService } from './services/app-config/app-config.service';
 
 import { HttpService } from './services/http-service/http-service.service';
 
@@ -28,7 +29,9 @@ import { HttpService } from './services/http-service/http-service.service';
     HttpClientModule,
     MaterialModule
   ],
-  providers: [ {provide: HTTP_INTERCEPTORS, useClass: HttpService, multi: true} ],
+  providers: [ 
+    AppConfigService, { provide: APP_INITIALIZER, useFactory: (configService: AppConfigService) => () => configService.loadConfigurationData(), deps: [AppConfigService], multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: HttpService, multi: true} ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/models/configuration-data.model.ts
+++ b/src/app/models/configuration-data.model.ts
@@ -1,0 +1,14 @@
+export interface ServiceDetail {
+    url: string;
+}
+
+export interface ServiceEndpoints {
+    [serviceName: string]: {
+        url: string;
+    };
+}
+
+export interface ConfigurationData {
+    serviceEndpoints: ServiceEndpoints;
+    something: string;
+}

--- a/src/app/services/app-config/app-config.service.spec.ts
+++ b/src/app/services/app-config/app-config.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AppConfigService } from './app-config.service';
+
+describe('AppConfigService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: AppConfigService = TestBed.get(AppConfigService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/app-config/app-config.service.ts
+++ b/src/app/services/app-config/app-config.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
+import { ConfigurationData } from '../../models/configuration-data.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+
+export class AppConfigService {
+  private _url: string = 'http://localhost:45603/api/configurationData';
+  private _configurationData: ConfigurationData;
+
+  constructor( private _http: HttpClient ) { }
+
+  public loadConfigurationData(): Promise<ConfigurationData> {
+    let parameters: HttpParams = new HttpParams(); 
+
+    let promise = this._http.get<ConfigurationData>(this._url, { params: parameters } ).toPromise<ConfigurationData>()
+    promise.catch(this.handleError);
+    promise.then( response => this._configurationData = response )//.then( response => console.log("Response: " + JSON.stringify(response)));
+    
+    return promise;
+  }
+
+  public GetConfigurationData(): ConfigurationData {
+    return this._configurationData;
+  }
+  
+  private handleError(error: HttpResponse<any> | any ): any {
+    let errorMessage: string;
+
+    // TODO: Can move some of this out to global interceptor
+    if( error instanceof HttpResponse ) {
+      const httpResponseError: HttpResponse<any> = error;
+      const body = httpResponseError.body || '';
+      const errorDetails = body.error || JSON.stringify(body);
+      
+      errorMessage = `${error.status} - ${error.statusText || ''} ${errorDetails}`;
+    } else {
+      errorMessage = error.message ? error.message : error.toString();
+    }
+
+    //TODO:
+    console.log(errorMessage);
+    return new Promise( (resolve) => { resolve(errorMessage) });
+  }
+}

--- a/src/app/services/reverse-captcha/reverse-captcha.service.ts
+++ b/src/app/services/reverse-captcha/reverse-captcha.service.ts
@@ -1,22 +1,34 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Subscription, Observable } from 'rxjs';
-import { SimpleResult} from '../../models/simple-result.model';
+import { Observable } from 'rxjs';
+import { SimpleResult } from '../../models/simple-result.model';
+import { AppConfigService } from '../app-config/app-config.service';
+import { ConfigurationData } from 'src/app/models/configuration-data.model';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ReverseCaptchaService {
-  //TODO: Get this from a config
-  private _url = 'http://localhost:45603/api/reverseCaptcha';
-  private _result: SimpleResult;
-  private _whatever: SimpleResult;
+  private _serviceKey: string = "reverse-captcha";
 
-  constructor(private _http: HttpClient) { }
+  constructor(private _http: HttpClient, private _appConfigService: AppConfigService) { }
 
-  calculate(digits: number): Observable<SimpleResult> {
-      let parameters: HttpParams = new HttpParams().set('input', digits.toString());
-      return this._http.get<SimpleResult>(this._url, { params: parameters } );
+  public calculate(digits: number): Observable<SimpleResult> {
+
+    if( this._appConfigService ) {
+      //TODO: We can wrap this in a helper
+      let configData: ConfigurationData = this._appConfigService.GetConfigurationData();
+      if( configData ) {
+        let endpoint = configData.serviceEndpoints[this._serviceKey];
+        if( endpoint ) {
+          let parameters: HttpParams = new HttpParams().set('input', digits.toString());
+          return this._http.get<SimpleResult>(endpoint.url, { params: parameters } );
+        } else {
+          //TODO: Only temporary
+          console.log("Nope, no endpoint");
+        }
+      }
+    }
   }
 
   //TODO: Can do in memory service to 'fake' the connection


### PR DESCRIPTION
- Simple Data Model for Configuration
- Wire in Provider to read in configuration when the application initializes
- Use configuration to pull endpoints
